### PR TITLE
[update] 詳細ウィンドウの更新をウィンドウを保持したまま行えるよう変更

### DIFF
--- a/custom_widgets.py
+++ b/custom_widgets.py
@@ -1,5 +1,4 @@
 import tkinter as tk
-import re
 
 #keys, configure関数必須
 class RestoreConfigure:
@@ -113,10 +112,15 @@ class GuideEntry(tk.Entry):
         -------------
         オプションなどはEntryの初期化と同様
         """
-        super().__init__(master)
-        self._alpha_str = ""
-        self._alpha_color= "SystemWindowText"
+        if "name" in kwargs:
+            super().__init__(master, name=kwargs["name"])
+            del kwargs["name"]
+        else:
+            super().__init__(master)
         self._entry = tk.Entry(master, kwargs)
+        self._alpha_str = tk.StringVar("")
+        self._alpha_color=self._entry.cget("fg")
+        self._defo_color=self._entry.cget("fg")
         self._strv = tk.StringVar(value= "")
         self._entry.configure(textvariable = self._strv)
 
@@ -129,8 +133,6 @@ class GuideEntry(tk.Entry):
         text : String
             Entry内のテキスト
         """
-        if ( self._strv.get() == self._alpha_str):
-            return ""
         return self._strv.get()
 
     def insert(self, str):
@@ -143,6 +145,7 @@ class GuideEntry(tk.Entry):
             Entry内に挿入するテキスト
         """
         self._strv.set(str)
+        self._init()
 
     def set_alpha_str(self, str):
         """
@@ -153,7 +156,8 @@ class GuideEntry(tk.Entry):
         str : String
             ガイドテキストに設定する文字列
         """
-        self._alpha_str=str
+        self._alpha_str.set(str)
+        self._init()
 
     def set_alpha_color(self, color ):
         """
@@ -165,50 +169,54 @@ class GuideEntry(tk.Entry):
             ガイドテキストに設定する色(指定形式はTkinterと同様)
         """
         self._alpha_color=color
+        self._init()
 
     def configure(self, **kwargs):
         self._entry.configure(kwargs)
+        self._init()
 
     def bind(self, *args):
         self._entry.bind(*args)
 
     def pack(self, **kwargs):
-        self._fg_color=self._entry.cget("fg")
+        self._init()
         self._entry.pack(kwargs)
 
-        def _mode_init(e):
-            self._entry.icursor(0)
-            self._entry.bind("<KeyPress>", _mode_wait)
-
-        def _mode_wait(e):
-            self._strv.set("")
-            self._entry.configure(fg=self._fg_color)
-            self._entry.unbind("<KeyPress>")
-            self._entry.unbind("<ButtonRelease>")
-            self._entry.bind("<KeyRelease>", _mode_enter)
-
-
-        def _mode_enter(e):
-            if self._strv.get() == "":
-                self._entry.configure(fg=self._alpha_color)
-                self._strv.set(self._alpha_str)
-                self._entry.icursor(0)
-                self._entry.bind("<KeyPress>", _mode_wait)
-                self._entry.bind("<ButtonRelease>", _mode_init)
-
-        if ( self._strv.get() == "" ):
-            self._entry.config(fg=self._alpha_color)
-            self._strv.set(self._alpha_str)
-            self._entry.bind("<ButtonRelease>", _mode_init)
+    def _init(self):
+        if ( self._strv.get() != ""):
+            self._mode_wait()
         else:
-            self._entry.bind("<KeyRelease>", _mode_enter)
+            self._mode_init()
 
+    def _mode_init(self, e=None):
+        def func(e):
+            self._entry.icursor(0)
+
+        self._entry.bind("<KeyPress>", self._mode_wait)
+        self._entry.config(textvariable=self._alpha_str, fg=self._alpha_color)
+        self._entry.bind("<ButtonRelease>", func)
+
+    def _mode_wait(self, e=None):
+
+        def func(e):
+            if self._strv.get() == "":
+                self._entry.unbind("<KeyRelease>")
+                self._mode_init()
+
+        self._entry.configure(fg=self._defo_color, textvariable=self._strv)
+        self._entry.unbind("<KeyPress>")
+        self._entry.unbind("<ButtonRelease>")
+        self._entry.bind("<KeyRelease>", func)
 
 #スクロールすることができるフレーム
 class ScrollFrame(tk.Frame):
 
     def __init__(self, master=None, **kwargs):
-        super().__init__(master)
+        if "name" in kwargs:
+            super().__init__(master, name=kwargs["name"])
+            del kwargs["name"]
+        else:
+            super().__init__(master)
         self._outframe=tk.Frame(master)
         self._canvas = tk.Canvas(self._outframe,bg="khaki2")
         self._inframe = tk.Frame(self._canvas, kwargs, pady = 10, bg="khaki2")
@@ -354,16 +362,16 @@ if __name__ == "__main__":
     root.title("Main Window")
     root.geometry("300x200")
 
-    def func():
-        print("gb_selected=", gb._selected)
-        gb.set_switch(True)
+    ge = GuideEntry(root)
+    ge.set_alpha_str("科目名")
+    ge.set_alpha_color("red")
+    ge.insert("最適化")
+    ge.pack()
 
-    gb = GuideButton(root, text="Guide Button", command=func)
-    gb.config_selected(bg="Khaki2")
-    gb.config_default(bg="Medium purple1", fg="ghostwhite")
-    gb.set_switch(False)
-    gb.pack(side=tk.LEFT)
+    bt1 = tk.Button(root, text="Button1", command= lambda : { ge.set_alpha_color("Khaki2")})
+    bt1.pack()
+    bt2 = tk.Button(root, text="Button2", command= lambda : print("text=", ge.get()))
+    bt2.pack()
 
-
-    gb.config_selected(command=func)
+    print(root.children)
     root.mainloop()

--- a/detail_window.py
+++ b/detail_window.py
@@ -174,8 +174,10 @@ class DetailWindow:
             self._win.destroy()
 
         has.set(True)
-        self._make_window()
+        if ( not self.has_window() ):
+            self._make_window()
         self._win.protocol('WM_DELETE_WINDOW', _protocol )
+        self._update()
         self._win.deiconify()
 
 
@@ -194,10 +196,10 @@ class DetailWindow:
         self._win.attributes("-topmost", True)
         self._win.bind("<Destroy>", self._rest_pos, "+")
         #frame設定
-        name_frame = tk.Frame(self._win, bg = self._colors["bg_front"], bd = 3, relief = tk.GROOVE)
-        memo_frame = tk.Frame(self._win, bg = self._colors["bg_back"], bd = 5)
-        commands_frame = tk.Frame(self._win, bg=self._colors["bg_back"],  bd = 3, padx=10)
-        kadai_frame = tk.Frame(self._win, bg = self._colors["bg_back"], bd = 5)
+        name_frame = tk.Frame(self._win, bg = self._colors["bg_front"], bd = 3, relief = tk.GROOVE, name="name_frame")
+        memo_frame = tk.Frame(self._win, bg = self._colors["bg_back"], bd = 5, name="memo_frame")
+        commands_frame = tk.Frame(self._win, bg=self._colors["bg_back"],  bd = 3, padx=10, name="commands_frame")
+        kadai_frame = tk.Frame(self._win, bg = self._colors["bg_back"], bd = 5, name = "kadai_frame")
         #frame配置
         name_frame.pack( ipadx = 20, fill = tk.X)
         memo_frame.pack( fill = tk.X)
@@ -205,9 +207,7 @@ class DetailWindow:
         kadai_frame.pack( expand = True, fill = tk.BOTH)
 
         #name_frame内
-        l_title = tk.Label(name_frame, text="科目名:", bg = self._colors["bg_front"], font = ("", 15, "bold"))
-        en_name = cw.GuideEntry(name_frame, font = ("", 15, "bold"), fg="ghostwhite", bg=self._colors["bg_en"], relief=tk.SOLID, insertbackground=self._colors["en_insertbg"], highlightbackground=self._colors["bg_front"], highlightcolor="SteelBlue2", highlightthickness=1)
-        en_name.insert(self._subject.get_name())
+        en_name = cw.GuideEntry(name_frame, font = ("", 15, "bold"), fg="ghostwhite", bg=self._colors["bg_en"], relief=tk.SOLID, insertbackground=self._colors["en_insertbg"], highlightbackground=self._colors["bg_front"], highlightcolor="SteelBlue2", highlightthickness=1, name="en_name")
         en_name.bind("<Return>", _focus_out)
         en_name.set_alpha_color("light sky blue")
         en_name.set_alpha_str("科目名")
@@ -217,8 +217,7 @@ class DetailWindow:
         #memo_frame内
         self._imgs["l_memo_title"]=tk.PhotoImage(file="./image/detail_window/ico_memo_32_white.png")
         l_memo_title = tk.Label(memo_frame, text="memo", bg = self._colors["bg_back"], fg = self._colors["fg_memo_title"], font = ("Century", 12), image=self._imgs["l_memo_title"], compound="left")
-        txb_memo = tk.Text(memo_frame, fg="ghostwhite", bg = self._colors["bg_en"], font=("HGSｺﾞｼｯｸM", 13), height = 6, insertbackground=self._colors["en_insertbg"], bd=1, relief=tk.SOLID)
-        txb_memo.insert(tk.END, self._subject.get_memo())
+        txb_memo = tk.Text(memo_frame, fg="ghostwhite", bg = self._colors["bg_en"], font=("HGSｺﾞｼｯｸM", 13), height = 6, insertbackground=self._colors["en_insertbg"], bd=1, relief=tk.SOLID, name="txb_memo")
 
         l_memo_title.pack(side=tk.TOP, anchor=tk.NW, pady = 3, padx = 10)
         txb_memo.pack(side=tk.BOTTOM, anchor=tk.SW, fill=tk.X, padx = 5, pady= 2)
@@ -227,13 +226,12 @@ class DetailWindow:
         self._imgs["l_kadai_title"]=tk.PhotoImage(file="./image/detail_window/ico_asig_title_32_black.png")
         self._imgs["l_kadai_announce"]=tk.PhotoImage(file="./image/detail_window/ico_announce_16_white.png")
         self._imgs["dummy"]=tk.PhotoImage(file="./image/detail_window/ico_toumei_32.png")
-        l_kadai_title = tk.Label(kadai_frame, text="課題一覧", bg = self._colors["bg_front"], fg="grey19", bd=3, font=("HGSｺﾞｼｯｸE", 15), relief = tk.GROOVE, image=self._imgs["l_kadai_title"], compound="left")
-        l_kadai_announce=tk.Label(kadai_frame, text="最近の締め切りは\"2022/6/7\"です", fg="ghostwhite",bg= self._colors["bg_back"], font=("", 10), image=self._imgs["l_kadai_announce"], compound="left", pady=3)
-        asig_frame=tk.Frame(kadai_frame, bg=self._colors["bg_back"])
-        sf_kadai= cw.ScrollFrame(asig_frame)
+        l_kadai_title = tk.Label(kadai_frame, text="課題一覧", bg = self._colors["bg_front"], fg="grey19", bd=3, font=("HGSｺﾞｼｯｸE", 15), relief = tk.GROOVE, image=self._imgs["l_kadai_title"], compound="left", name="l_kadai_title")
+        l_kadai_announce=tk.Label(kadai_frame, text="最近の締め切りは\"2022/6/7\"です", fg="ghostwhite",bg= self._colors["bg_back"], font=("", 10), image=self._imgs["l_kadai_announce"], compound="left", pady=3, name="l_kadai_announce")
+        asig_frame=tk.Frame(kadai_frame, bg=self._colors["bg_back"], name="asig_frame")
+        sf_kadai= cw.ScrollFrame(asig_frame, name="sf_kadai")
 
         def _add_asig():
-
             ias=ia.InputAssignment()
 
             def _add_widget():
@@ -278,6 +276,20 @@ class DetailWindow:
         bt_restore.pack(side=tk.LEFT, padx=10)
         bt_add_asig.pack(side=tk.LEFT, padx=10)
 
+    def _update(self):
+        name_frame = self._find("name_frame")
+        memo_frame = self._find("memo_frame")
+        kadai_frame = self._find("kadai_frame")
+
+        en_name=self._find("en_name", name_frame)
+        txb_memo=self._find("txb_memo", memo_frame)
+        l_kadai_announce=self._find("l_kadai_announce", kadai_frame)
+        sf_kadai = self._find("sf_kadai", kadai_frame)
+
+        en_name.insert(self._subject.get_name())
+        txb_memo.delete("1.0", "end")
+        txb_memo.insert("1.0", self._subject.get_memo())
+
     #windowの削除
     def _destory(self):
         if self.has_window():
@@ -289,6 +301,21 @@ class DetailWindow:
             self._x=self._win.winfo_x()
             self._y=self._win.winfo_y()
 
+    def _find(self, name, widget = None):
+        if widget == None:
+            if self._win == None:
+                return None
+            else:
+                widget = self._win
+
+        if name in widget.children:
+            return widget.nametowidget(name)
+        else:
+            for v in widget.children.values():
+                tmp = self._find(name, v)
+                if tmp != None:
+                    return tmp
+            return None
 
 if __name__ == "__main__":
 
@@ -305,41 +332,26 @@ if __name__ == "__main__":
 
     def func():
         # subject=dw.get()
-        print(subject.get_name())
+        print(dw.get().get_name())
         print("memo:")
-        print(subject.get_memo())
+        print(dw.get().get_memo())
 
-    def func2(e, base):
-        print(str(e.widget))
-        print(base)
-
-    def func3():
-        print("window destroied")
-
-    def func4():
-        print("press restore")
-
-    def func5():
-        print(f"x,y = {dw._x}, {dw._y}")
-        print(f"x,y == {dw._win.winfo_x()}, {dw._win.winfo_y()}")
-
-
-    dw.set_func("window_closed", func3)
-    dw.set_func("on_restore", func4)
-
+    def func2():
+        tmp = sb.Subject()
+        tmp.set_name("最適化2")
+        tmp.set_memo("過去問無し、出席点あり")
+        dw.set_subject(tmp)
+        dw.show_window()
+        
     has = tk.BooleanVar(value=True)
     but1 = tk.Button(root, text = "サブウィンドウ表示", command = partial(dw.show_window, has))
     but1.pack()
     but2 = tk.Button(root, text = "Subject取得", command=func)
     but2.pack()
     frame1 = tk.Frame(root)
-    but3 = tk.Button(frame1, text="座標取得", command=func5, name="but3")
-    but3.pack()
-    label1 = tk.Label(frame1, text="Label1", name="label1")
-    label1.pack()
-    frame1.pack()
+    but4 = tk.Button(root, text="サブジェクト変更", command=func2)
+    but4.pack()
 
-    print(frame1.children)
-    print(root.children)
+
     root.mainloop()
     print(has.get())


### PR DESCRIPTION
[update] DetailWindow
ウィンドウの内容をウィンドウを破棄せずに更新できるよう変更
これによって,set_subject()によってsubjectを設定後にshow_window()によって
ウィンドウを破棄せずに内容を更新するようになった

[update] GuideEntry & ScrollFrame
DetailWindowの変更に伴い、__init__の仕様を変更
nameオプションをクラス自身に定義できるようになった