### PR TITLE
[add & updatea] Subjectの課題保持の仕様を変更

### DIFF
--- a/subject.py
+++ b/subject.py
@@ -2,11 +2,13 @@
 # *** do not edit ***
 
 from datetime import datetime
+from copy import copy
 
 class Assignment:
     def __init__(self, name="", deadline=datetime.max):
         self._name = name
         self._deadline = deadline
+        self._make_date = datetime.now() #課題の作成時刻
 
     # 課題名を設定する
     def set_name(self, name):
@@ -22,26 +24,42 @@ class Assignment:
     def get_deadline(self):
         return self._deadline
 
+    def get_make_date(self): #作成時刻が変化しないようにコピーを返す
+        tmp = copy(self._make_date)
+        return tmp
+
     def __str__(self):
         return f"name={self._name} deadline={str(self._deadline)}"
 
 class Subject:
     def __init__(self):
         self._name = ""
-        self._assignments = []
+        self._assignments = {} #課題名をkeyに取る
         self._memo = ""
-        self._asg_num = 0
 
     # 課題の数を１つ増やす
-    def add_asg(self, assignment = Assignment()):
-        self._assignments.append(assignment)
-        self._asg_num += 1
+    #課題名をキーにとっているため、デフォルト名は＊課題{数字} 最大1万個
+    def add_asg(self, assignment = None):
+        if assignment == None:
+            tname = ""
+            cnt = 1
+            while( cnt < 10000 ):
+                tname=f"*課題{cnt}"
+                if not tname in self._assignments:
+                    break
+                cnt += 1
+            assignment = Assignment(name=tname)
+
+        if assignment.get_name() in self._assignments:
+            print("課題が重複しています")
+        else:
+            self._assignments[assignment.get_name()] = assignment
 
     # id番目の課題を削除する（[a, b, c]の中から2番目=bを削除すると[a, c]になる）
     def del_asg(self, id):
         if id < self._asg_num and id >= 0:
-            del self._assignments[id]
-            self._asg_num -= 1
+            tmp = sorted(self._assignments.values(), key= lambda x: x.get_make_date())
+            del self._assignments[tmp[id].get_name()]
 
     # 科目名を設定する
     def set_name(self, name):
@@ -58,40 +76,32 @@ class Subject:
 
     # 課題の数を返す
     def get_asg_num(self):
-        return self._asg_num
+        return len(self._assignments)
 
-    # id番目の課題の名前を設定する
+    # # id番目の課題の名前を設定する
     def set_asg_name(self, id, name):
-        if id < self._asg_num and id >= 0:
-            self._assignments[id].set_name(name)
+        if id < self.get_asg_num() and id >= 0:
+            tmp = sorted(self._assignments.values(), key= lambda x: x.get_make_date())
+            tmp[id].set_name(name)
 
     # id番目の課題の締切日を設定する
     def set_asg_deadline(self, id, year, month, day, hour, minutes):
-        if id < self._asg_num and id >= 0:
-            self._assignments[id].set_deadline(year, month, day, hour, minutes)
+        if id < self.get_asg_num() and id >= 0:
+            tmp = sorted(self._assignments.values(), key= lambda x: x.get_make_date())
+            tmp[id].set_deadline(year, month, day, hour, minutes)
 
     # 締切日が最も近い課題の名前を返す
     def get_close_asg_name(self):
-        if self._asg_num == 0:
+        if not self.get_asg_num():
             return ""
         else:
-            min_d = self._assignments[0].get_deadline()
-            min_n = self._assignments[0].get_name()
-            for i in range(1, self._asg_num):
-                if min_d > self._assignments[i].get_deadline():
-                    min_d = self._assignments[i].get_deadline()
-                    min_n = self._assignments[i].get_name()
-
-            return min_n
+            min_a = min(self._assignments.values(), key = lambda x : x.get_deadline())
+        return min_a.get_name()
 
     # 締切日が最も近い課題の締切日を返す
     def get_close_asg_deadline(self):
-        if self._asg_num == 0:
+        if not self.get_asg_num():
             return datetime.max
         else:
-            min_d = self._assignments[0].get_deadline()
-            for i in range(1, self._asg_num):
-                if min_d > self._assignments[i].get_deadline():
-                    min_d = self._assignments[i].get_deadline()
-
-            return min_d
+            min_a = min(self._assignments.values(), key = lambda x : x.get_deadline())
+        return min_a.get_deadline()


### PR DESCRIPTION
[update] Subject
_assignmentsを課題名をキーに取る辞書型に変更
set_asg_nameなどの関数の引数idは作成時刻を基準としている
_asg_numの削除

[add] Assignment
クラスの作成時刻を表す_make_dateを追加
この変更による既存の利用への影響はなし